### PR TITLE
fix(react): add repository field for provenance verification

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@roadlittledawn/docs-design-system-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "description": "React components for documentation design system",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/roadlittledawn/docs-design-system",
+    "directory": "packages/react"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

- Add `repository` field to package.json for NPM OIDC provenance verification
- Bump version to 0.1.2

The previous publish failed because provenance verification requires the `repository.url` to match the GitHub repo.

## Test plan

- [ ] Merge to main
- [ ] Verify publish workflow succeeds with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)