### PR TITLE
Fix Netlify build: build React package first

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -19,6 +19,8 @@ jobs:
       
       - run: npm ci
       
+      - run: npm run build --workspace=packages/react
+      
       - run: npm run build --workspace=website
       
       - uses: nwtgck/actions-netlify@v3
@@ -44,6 +46,8 @@ jobs:
           cache: 'npm'
       
       - run: npm ci
+      
+      - run: npm run build --workspace=packages/react
       
       - run: npm run build-storybook
       


### PR DESCRIPTION
Fixes build failure in GitHub Actions by building the React package before website and Storybook.

The builds were failing because  didn't exist yet.