### PR TITLE
fix(website:gallery): specify y gap on all screen sizes

### DIFF
--- a/website/pages/gallery/index.tsx
+++ b/website/pages/gallery/index.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 export default function GalleryPage() {
   const data = galleryData as GalleryData;
   const sortedSites = [...data.sites].sort((a, b) =>
-    a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
   );
 
   return (
@@ -22,7 +22,7 @@ export default function GalleryPage() {
         </p>
       </div>
 
-      <div className="grid md:gap-x-6 md:gap-y-16 md:grid-cols-2 lg:grid-cols-3 lg:gap-x-6 lg:gap-y-16">
+      <div className="grid gap-y-16 md:gap-x-6 md:grid-cols-2 lg:grid-cols-3 lg:gap-x-6">
         {sortedSites.map((site) => (
           <Link
             key={site.id}


### PR DESCRIPTION
## Summary

On mobile screens the grid gap Y was not being applied. Just applied Y gap for all screen sizes

## Screenshot (mobile size)
<img width="548" height="958" alt="Screenshot 2026-03-04 at 17 24 02" src="https://github.com/user-attachments/assets/a6b9ed59-6112-4bb6-bdd9-d9b7f106b249" />
