### PR TITLE
Replace Clear quality attribute with Complete

### DIFF
--- a/website/pages/principles/quality-metrics.mdx
+++ b/website/pages/principles/quality-metrics.mdx
@@ -15,8 +15,8 @@ Great documentation can be evaluated against six core quality attributes. These 
   <Card title="Relevant">
     Content directly addresses user needs and goals. Information is appropriate for the audience and context, without tangential details.
   </Card>
-  <Card title="Clear">
-    Content is easy to understand with straightforward language, logical structure, and well-explained concepts. Readers grasp the meaning without confusion.
+  <Card title="Complete">
+    Content contains all necessary information for users to understand and accomplish their goals. All required components are present with sufficient context and examples.
   </Card>
   <Card title="Concise">
     Information is expressed efficiently without unnecessary words or redundancy. Every sentence serves a purpose and respects the reader's time.


### PR DESCRIPTION
Replaces the Clear card in the quality metrics page with Completeness, sourced from the review-for-quality skill definition.