### PR TITLE
Fix publish workflow: bump to Node 24, remove broken npm update step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Check if version changed
         id: version-check


### PR DESCRIPTION
## Summary

- Bumps Node.js from 22 → 24 in the publish workflow
- Removes the `npm install -g npm@latest` step that was failing with `MODULE_NOT_FOUND: promise-retry`

Node 24 ships with npm 10.x which has built-in OIDC/provenance support, so the update step is no longer needed.

## Test plan
- [ ] Merge to develop, then develop → main and verify the publish workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)