### PR TITLE
fix: remove CSS sideeffect imports from Tile/TileGrid

### DIFF
--- a/packages/react/USAGE.md
+++ b/packages/react/USAGE.md
@@ -274,7 +274,7 @@ import { CardGrid } from "@roadlittledawn/docs-design-system-react";
 
 ## Tile
 
-A compact, clickable item designed for dense listing patterns — integrations, frameworks, plugins, skills, etc. Unlike `Card`, Tile has a fixed layout (icon left, title right) and a simpler, more opinionated API.
+A compact, clickable item designed for dense listing patterns — integrations, frameworks, plugins, skills, etc. Unlike `Card`, Tile has a fixed layout (icon left, title right) and a simpler, more opinionated API. Styles are provided via the package's global `styles.css` — no per-component CSS import is needed.
 
 ### When to Use
 

--- a/packages/react/USAGE.md
+++ b/packages/react/USAGE.md
@@ -274,7 +274,7 @@ import { CardGrid } from "@roadlittledawn/docs-design-system-react";
 
 ## Tile
 
-A compact, clickable item designed for dense listing patterns — integrations, frameworks, plugins, skills, etc. Unlike `Card`, Tile has a fixed layout (icon left, title right) and a simpler, more opinionated API. Styles are provided via the package's global `styles.css` — no per-component CSS import is needed.
+A compact, clickable item designed for dense listing patterns — integrations, frameworks, plugins, skills, etc. Unlike `Card`, Tile has a fixed layout (icon left, title right) and a simpler, more opinionated API. Styles are provided via `@roadlittledawn/docs-design-system-react/styles.css` — no per-component CSS import is needed.
 
 ### When to Use
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadlittledawn/docs-design-system-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "MIT",
   "description": "React components for documentation design system",
   "repository": {

--- a/packages/react/src/components/Tile.tsx
+++ b/packages/react/src/components/Tile.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import "./Tile.css";
 
 export interface TileProps {
   /** Tile heading text (required) */

--- a/packages/react/src/components/TileGrid.tsx
+++ b/packages/react/src/components/TileGrid.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from "react";
-import "./TileGrid.css";
 
 export interface TileGridProps {
   /**

--- a/storybook/public/llms.txt
+++ b/storybook/public/llms.txt
@@ -176,7 +176,7 @@ import { CardGrid } from '@roadlittledawn/docs-design-system-react';
 
 ## Tile
 
-A compact, clickable item for dense listing patterns — integrations, frameworks, plugins, skills. Fixed icon-left layout with a simpler API than Card. Styles are provided via the package's global `styles.css` — no per-component CSS import is needed.
+A compact, clickable item for dense listing patterns — integrations, frameworks, plugins, skills. Fixed icon-left layout with a simpler API than Card. Styles are provided via `@roadlittledawn/docs-design-system-react/styles.css` — no per-component CSS import is needed.
 
 ### Import
 

--- a/storybook/public/llms.txt
+++ b/storybook/public/llms.txt
@@ -176,7 +176,7 @@ import { CardGrid } from '@roadlittledawn/docs-design-system-react';
 
 ## Tile
 
-A compact, clickable item for dense listing patterns — integrations, frameworks, plugins, skills. Fixed icon-left layout with a simpler API than Card.
+A compact, clickable item for dense listing patterns — integrations, frameworks, plugins, skills. Fixed icon-left layout with a simpler API than Card. Styles are provided via the package's global `styles.css` — no per-component CSS import is needed.
 
 ### Import
 


### PR DESCRIPTION
## Summary

- Removes `import "./Tile.css"` and `import "./TileGrid.css"` from the component source files — these referenced files not shipped in `dist/`, breaking consumers in React Server Component contexts
- Styles are already bundled into `dist/styles.css` via the PostCSS pipeline, consistent with all other components

## Test plan

- [x] `npm run build` passes
- [x] `npm run type-check` passes
- [x] Verified `dist/components/Tile.js` and `TileGrid.js` no longer contain CSS imports
- [ ] Consumer project using `compileMDX` from `next-mdx-remote/rsc` builds without `Module not found: Can't resolve './Tile.css'`

Fixes #160